### PR TITLE
feat: global - global success response 추가#26

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
@@ -1,0 +1,35 @@
+package com.ioteam.order_management_platform.global.success;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+
+	// user
+	USER_SIGNUP(HttpStatus.CREATED, "회원가입이 성공적으로 완료되었습니다.", "S_USER_SIGNUP"),
+	USER_LOGIN(HttpStatus.OK, "로그인에 성공하였습니다.", "S_USER_LOGIN"),
+	USER_DETAILS_INFO(HttpStatus.OK, "회원 정보를 가져오는데에 성공하였습니다.", "S_USER_DETAILS_INFO"),
+	USER_INFO(HttpStatus.OK, "모든 회원 정보를 가져오는데에 성공하였습니다.", "S_USER_INFO");
+
+	// review
+
+	// restaurant
+
+	// category
+
+	// order
+
+	// menu
+
+	// payment
+
+	// ai
+
+	private final HttpStatus statusCode;
+	private final String message;
+	private final String code;
+}


### PR DESCRIPTION
- Global로 사용 가능한 도메인별 success 코드 추가

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 각 도메인의 controller에서 직접 성공 message 응답

- **to-be**
  - global에서 정의한 success code enum화하여 controller에서 가져와 활용

## 코멘트
