### PR TITLE
feat: user - User 전체 조회하기

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
@@ -2,6 +2,9 @@ package com.ioteam.order_management_platform.user.controller;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -13,11 +16,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.ioteam.order_management_platform.global.dto.CommonPageResponse;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
 import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.user.dto.AdminUserResponseDto;
 import com.ioteam.order_management_platform.user.dto.LoginRequestDto;
 import com.ioteam.order_management_platform.user.dto.SignupRequestDto;
 import com.ioteam.order_management_platform.user.dto.UserInfoResponseDto;
+import com.ioteam.order_management_platform.user.dto.UserSearchCondition;
 import com.ioteam.order_management_platform.user.exception.UserException;
 import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
 import com.ioteam.order_management_platform.user.service.UserService;
@@ -74,5 +80,18 @@ public class UserController {
 		@PathVariable UUID userId) {
 		UserInfoResponseDto userInfo = userService.getUserByUserId(userDetails, userId);
 		return ResponseEntity.ok(new CommonResponse<>("사용자 조회 성공", userInfo));
+	}
+
+	@GetMapping("/all")
+	public ResponseEntity<CommonResponse<CommonPageResponse<AdminUserResponseDto>>> searchUsers(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		UserSearchCondition condition,
+		@PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		CommonPageResponse<AdminUserResponseDto> pageResponse = userService.searchUsersByCondition(userDetails,
+			condition, pageable);
+		return ResponseEntity.ok(new CommonResponse<>(
+			"전체 사용자 조회 성공",
+			pageResponse));
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/user/dto/AdminUserResponseDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/dto/AdminUserResponseDto.java
@@ -1,0 +1,48 @@
+package com.ioteam.order_management_platform.user.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.user.entity.User;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class AdminUserResponseDto {
+
+	private final UUID userId;
+	private final String username;
+	private final String password;
+	private final String nickname;
+	private final String email;
+	private final UserRoleEnum role;
+	private final LocalDateTime createdAt;
+	private final UUID createdBy;
+	private final LocalDateTime modifiedAt;
+	private final UUID modifiedBy;
+	private final LocalDateTime deletedAt;
+	private final UUID deletedBy;
+
+	public static AdminUserResponseDto from(User user) {
+		return AdminUserResponseDto
+			.builder()
+			.userId(user.getUserId())
+			.username(user.getUsername())
+			.password(user.getPassword())
+			.nickname(user.getNickname())
+			.email(user.getEmail())
+			.role(user.getRole())
+			.createdAt(user.getCreatedAt())
+			.createdBy(user.getCreatedBy())
+			.modifiedAt(user.getModifiedAt())
+			.modifiedBy(user.getModifiedBy())
+			.deletedAt(user.getDeletedAt())
+			.deletedBy(user.getDeletedBy())
+			.build();
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/user/dto/UserSearchCondition.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/dto/UserSearchCondition.java
@@ -1,0 +1,17 @@
+package com.ioteam.order_management_platform.user.dto;
+
+import java.time.LocalDateTime;
+
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UserSearchCondition {
+	private LocalDateTime startCreatedAt;
+	private LocalDateTime endCreatedAt;
+	private UserRoleEnum role;
+	private Boolean isDeleted;
+}

--- a/src/main/java/com/ioteam/order_management_platform/user/exception/UserException.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/exception/UserException.java
@@ -19,7 +19,9 @@ public enum UserException implements ExceptionType {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 ID가 존재하지 않습니다.", "E_USER_NOT_FOUND"),
 	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "로그인한 유저와 일치하지 않습니다.", "E_UNAUTHORIZED_ACCESS"),
 	INVALID_USERNAME(HttpStatus.UNAUTHORIZED, "사용자 정보가 없습니다.", "E_INVALID_USERNAME"),
-	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "암호가 틀렸습니다.", "E_INVALID_PASSWORD");
+	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "암호가 틀렸습니다.", "E_INVALID_PASSWORD"),
+	INVALID_PERIOD(HttpStatus.UNPROCESSABLE_ENTITY, "기간 검색 조건이 적합하지 않습니다.", "E_INVALID_P"),
+	NO_PERMISSION(HttpStatus.UNAUTHORIZED, "관리자 권한이 필요합니다.", "E_NO_PERMISSION");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepository.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ioteam.order_management_platform.user.entity.User;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserRepositoryCustom {
 	Optional<User> findByUsername(String username);
 
 	Optional<User> findByEmail(String email);

--- a/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ioteam.order_management_platform.user.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.ioteam.order_management_platform.user.dto.UserSearchCondition;
+import com.ioteam.order_management_platform.user.entity.User;
+
+public interface UserRepositoryCustom {
+	Page<User> searchUserByCondition(UserSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,93 @@
+package com.ioteam.order_management_platform.user.repository;
+
+import static com.ioteam.order_management_platform.user.entity.QUser.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.user.dto.UserSearchCondition;
+import com.ioteam.order_management_platform.user.entity.User;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.exception.UserException;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<User> searchUserByCondition(UserSearchCondition condition, Pageable pageable) {
+		List<User> content = queryFactory.select(user)
+			.from(user)
+			.where(
+				betweenPeriod(condition.getStartCreatedAt(), condition.getEndCreatedAt()),
+				eqRole(condition.getRole()),
+				isDeleted(condition.getIsDeleted())
+			)
+			.orderBy(createOrderSpecifiers(pageable.getSort()))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(user.count())
+			.from(user)
+			.where(
+				betweenPeriod(condition.getStartCreatedAt(), condition.getEndCreatedAt()),
+				eqRole(condition.getRole()),
+				isDeleted(condition.getIsDeleted())
+			);
+
+		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+	}
+
+	private BooleanExpression betweenPeriod(LocalDateTime startCreatedAt, LocalDateTime endCreatedAt) {
+		if (startCreatedAt == null || endCreatedAt == null)
+			return null;
+		if (startCreatedAt.isAfter(endCreatedAt))
+			throw new CustomApiException(UserException.INVALID_PERIOD);
+		return user.createdAt.between(startCreatedAt, endCreatedAt);
+	}
+
+	private BooleanExpression eqRole(UserRoleEnum role) {
+		if (role == null)
+			return null;
+		return user.role.eq(role);
+	}
+
+	private BooleanExpression isDeleted(Boolean isDeleted) {
+		if (isDeleted == null)
+			return null;
+		if (isDeleted)
+			return user.deletedAt.isNotNull();
+		return user.deletedAt.isNull();
+	}
+
+	private OrderSpecifier[] createOrderSpecifiers(Sort sort) {
+		return sort.stream()
+			.filter(order -> List.of("role", "createdAt").contains(order.getProperty()))
+			.map(order -> {
+				Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+				switch (order.getProperty()) {
+					case "createdAt":
+						return new OrderSpecifier<>(direction, user.createdAt);
+					case "role":
+						return new OrderSpecifier<>(direction, user.role);
+				}
+				return null;
+			})
+			.toArray(OrderSpecifier[]::new);
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/user/service/UserService.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/service/UserService.java
@@ -3,13 +3,18 @@ package com.ioteam.order_management_platform.user.service;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.ioteam.order_management_platform.global.dto.CommonPageResponse;
 import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.user.dto.AdminUserResponseDto;
 import com.ioteam.order_management_platform.user.dto.LoginRequestDto;
 import com.ioteam.order_management_platform.user.dto.SignupRequestDto;
 import com.ioteam.order_management_platform.user.dto.UserInfoResponseDto;
+import com.ioteam.order_management_platform.user.dto.UserSearchCondition;
 import com.ioteam.order_management_platform.user.entity.User;
 import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
 import com.ioteam.order_management_platform.user.exception.UserException;
@@ -95,5 +100,17 @@ public class UserService {
 		User user = userRepository.findByUserId(userId)
 			.orElseThrow(() -> new CustomApiException(UserException.USER_NOT_FOUND));
 		return UserInfoResponseDto.from(user);
+	}
+
+	public CommonPageResponse<AdminUserResponseDto> searchUsersByCondition(UserDetailsImpl userDetails,
+		UserSearchCondition condition,
+		Pageable pageable) {
+		UserRoleEnum role = userDetails.getUser().getRole();
+		if (role != UserRoleEnum.MASTER && role != UserRoleEnum.MANAGER) {
+			throw new CustomApiException(UserException.NO_PERMISSION);
+		}
+		Page<AdminUserResponseDto> userDtoList = userRepository.searchUserByCondition(condition, pageable)
+			.map(AdminUserResponseDto::from);
+		return new CommonPageResponse<>(userDtoList);
 	}
 }


### PR DESCRIPTION
- 검색 조건 정의
- MASTER, MANAGER 권한만 사용 가능하게 설정

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
- **to-be**
  - 전체 사용자에 대한 정보를 조회할 수 있는 기능 추가
  - 사용자 조건(role, 생성 날짜)에 따른 조회 기능
  - MANAGER, MASTER만 사용할 수 있는 권한 설정

## 코멘트
