### PR TITLE
Feat/#32 user api refactoring

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
@@ -7,8 +7,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,19 +17,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ioteam.order_management_platform.global.dto.CommonPageResponse;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
-import com.ioteam.order_management_platform.global.exception.CustomApiException;
 import com.ioteam.order_management_platform.user.dto.AdminUserResponseDto;
 import com.ioteam.order_management_platform.user.dto.LoginRequestDto;
 import com.ioteam.order_management_platform.user.dto.SignupRequestDto;
 import com.ioteam.order_management_platform.user.dto.UserInfoResponseDto;
 import com.ioteam.order_management_platform.user.dto.UserSearchCondition;
-import com.ioteam.order_management_platform.user.exception.UserException;
 import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
 import com.ioteam.order_management_platform.user.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -44,37 +40,14 @@ public class UserController {
 
 	@PostMapping("/signup")
 	@Operation(summary = "회원가입", description = "회원가입은 인증/비인증 회원 모두 사용 가능")
-	public ResponseEntity<CommonResponse<Void>> signup(@Valid @RequestBody SignupRequestDto requestDto,
-		BindingResult bindingResult) {
-		// Validation 예외처리
-		if (bindingResult.hasErrors()) {
-			for (FieldError error : bindingResult.getFieldErrors()) {
-				log.error("Validation error - field: {}, message: {}", error.getField(), error.getDefaultMessage());
-
-				switch (error.getField()) {
-					case "nickname":
-						throw new CustomApiException(UserException.EMPTY_NICKNAME);
-					case "username":
-						throw new CustomApiException(UserException.EMPTY_USERNAME);
-					case "password":
-						throw new CustomApiException(UserException.EMPTY_PASSWORD);
-					case "email":
-						if ("Email".equals(error.getCode())) {
-							throw new CustomApiException(UserException.INVALID_EMAIL_FORMAT);
-						}
-						throw new CustomApiException(UserException.EMPTY_EMAIL);
-					default:
-						throw new CustomApiException(UserException.INVALID_USER_INFO);
-				}
-			}
-		}
+	public ResponseEntity<CommonResponse<Void>> signup(@RequestBody @Validated SignupRequestDto requestDto) {
 		userService.signup(requestDto);
 		return ResponseEntity.ok(new CommonResponse<>("회원가입이 성공적으로 완료되었습니다.", null));
 	}
 
 	@PostMapping("/login")
 	@Operation(summary = "로그인", description = "로그인은 인증/비인증 회원 모두 사용 가능")
-	public ResponseEntity<CommonResponse<String>> login(@Valid @RequestBody LoginRequestDto requestDto) {
+	public ResponseEntity<CommonResponse<String>> login(@RequestBody @Validated LoginRequestDto requestDto) {
 		String token = userService.login(requestDto);
 		return ResponseEntity.ok(new CommonResponse<>("로그인이 되었습니다.", token));
 	}

--- a/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ioteam.order_management_platform.global.dto.CommonPageResponse;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
+import com.ioteam.order_management_platform.global.success.SuccessCode;
 import com.ioteam.order_management_platform.user.dto.AdminUserResponseDto;
 import com.ioteam.order_management_platform.user.dto.LoginRequestDto;
 import com.ioteam.order_management_platform.user.dto.SignupRequestDto;
@@ -42,14 +43,14 @@ public class UserController {
 	@Operation(summary = "회원가입", description = "회원가입은 인증/비인증 회원 모두 사용 가능")
 	public ResponseEntity<CommonResponse<Void>> signup(@RequestBody @Validated SignupRequestDto requestDto) {
 		userService.signup(requestDto);
-		return ResponseEntity.ok(new CommonResponse<>("회원가입이 성공적으로 완료되었습니다.", null));
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.USER_SIGNUP, null));
 	}
 
 	@PostMapping("/login")
 	@Operation(summary = "로그인", description = "로그인은 인증/비인증 회원 모두 사용 가능")
 	public ResponseEntity<CommonResponse<String>> login(@RequestBody @Validated LoginRequestDto requestDto) {
 		String token = userService.login(requestDto);
-		return ResponseEntity.ok(new CommonResponse<>("로그인이 되었습니다.", token));
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.USER_LOGIN, token));
 	}
 
 	@GetMapping("/{userId}")
@@ -58,7 +59,7 @@ public class UserController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID userId) {
 		UserInfoResponseDto userInfo = userService.getUserByUserId(userDetails, userId);
-		return ResponseEntity.ok(new CommonResponse<>("사용자 조회 성공", userInfo));
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.USER_DETAILS_INFO, userInfo));
 	}
 
 	@GetMapping("/all")
@@ -70,8 +71,6 @@ public class UserController {
 	) {
 		CommonPageResponse<AdminUserResponseDto> pageResponse = userService.searchUsersByCondition(userDetails,
 			condition, pageable);
-		return ResponseEntity.ok(new CommonResponse<>(
-			"전체 사용자 조회 성공",
-			pageResponse));
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.USER_INFO, pageResponse));
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/controller/UserController.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.ioteam.order_management_platform.global.dto.CommonPageResponse;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
@@ -28,18 +28,22 @@ import com.ioteam.order_management_platform.user.exception.UserException;
 import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
 import com.ioteam.order_management_platform.user.service.UserService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
+@Tag(name = "사용자", description = "사용자 API")
 public class UserController {
 	private final UserService userService;
 
 	@PostMapping("/signup")
+	@Operation(summary = "회원가입", description = "회원가입은 인증/비인증 회원 모두 사용 가능")
 	public ResponseEntity<CommonResponse<Void>> signup(@Valid @RequestBody SignupRequestDto requestDto,
 		BindingResult bindingResult) {
 		// Validation 예외처리
@@ -69,12 +73,14 @@ public class UserController {
 	}
 
 	@PostMapping("/login")
+	@Operation(summary = "로그인", description = "로그인은 인증/비인증 회원 모두 사용 가능")
 	public ResponseEntity<CommonResponse<String>> login(@Valid @RequestBody LoginRequestDto requestDto) {
 		String token = userService.login(requestDto);
 		return ResponseEntity.ok(new CommonResponse<>("로그인이 되었습니다.", token));
 	}
 
 	@GetMapping("/{userId}")
+	@Operation(summary = "사용자 상세 조회", description = "사용자 상세 조회는 인증된 회원만 사용 가능")
 	public ResponseEntity<CommonResponse<UserInfoResponseDto>> getUserByUserId(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@PathVariable UUID userId) {
@@ -83,6 +89,7 @@ public class UserController {
 	}
 
 	@GetMapping("/all")
+	@Operation(summary = "사용자 전체 조회", description = "사용자 전체 조회는 MANAGER와 MASTER만 사용 가능")
 	public ResponseEntity<CommonResponse<CommonPageResponse<AdminUserResponseDto>>> searchUsers(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		UserSearchCondition condition,

--- a/src/main/java/com/ioteam/order_management_platform/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/dto/LoginRequestDto.java
@@ -1,11 +1,9 @@
 package com.ioteam.order_management_platform.user.dto;
 
 import lombok.Getter;
-import lombok.Setter;
 
-@Setter
 @Getter
 public class LoginRequestDto {
-    private String username;
-    private String password;
+	private String username;
+	private String password;
 }

--- a/src/main/java/com/ioteam/order_management_platform/user/dto/SignupRequestDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/dto/SignupRequestDto.java
@@ -1,24 +1,40 @@
 package com.ioteam.order_management_platform.user.dto;
 
+import com.ioteam.order_management_platform.user.entity.User;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
+@Builder
+@AllArgsConstructor
 @Getter
-@Setter
 public class SignupRequestDto {
-    @NotBlank(message = "nickname은 공백일 수 없습니다.")
-    private String nickname;
-    @NotBlank(message = "username은 공백일 수 없습니다.")
-    private String username;
-    @NotBlank(message = "password는 공백일 수 없습니다.")
-    private String password;
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    @NotBlank(message = "email은 공백일 수 없습니다.")
-    private String email;
-    private boolean admin = false;
-    private boolean owner = false;
-    private String adminToken = "";
-    private String ownerToken = "";
+	@NotBlank(message = "nickname은 공백일 수 없습니다.")
+	private String nickname;
+	@NotBlank(message = "username은 공백일 수 없습니다.")
+	private String username;
+	@NotBlank(message = "password는 공백일 수 없습니다.")
+	private String password;
+	@Email(message = "올바른 이메일 형식이 아닙니다.")
+	@NotBlank(message = "email은 공백일 수 없습니다.")
+	private String email;
+	private boolean admin = false;
+	private boolean owner = false;
+	private String adminToken = "";
+	private String ownerToken = "";
+
+	public User toEntity(String password, UserRoleEnum role) {
+		return User
+			.builder()
+			.nickname(this.nickname)
+			.username(this.username)
+			.password(password)
+			.role(role)
+			.email(this.email)
+			.build();
+	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/user/security/WebSecurityConfig.java
+++ b/src/main/java/com/ioteam/order_management_platform/user/security/WebSecurityConfig.java
@@ -68,8 +68,8 @@ public class WebSecurityConfig {
 				.permitAll() // resources 접근 허용 설정
 				.requestMatchers("/v3/api-docs", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**")
 				.permitAll() // swagger 문서 접근 허용
-				.requestMatchers("/api/users/**") // todo. 수정 필요
-				.permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
+				.requestMatchers("/api/users/login", "/api/users/signup")
+				.permitAll() // '/api/users/login' 과 '/api/users/signup' 으로 시작하는 요청 모두 접근 허가
 				.anyRequest()
 				.permitAll() //.authenticated() // 그 외 모든 요청 인증처리
 		);


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 추상화되지 않은 서비스 레이어
  - success response base 사용하지 않음
  - 중복되는 valid
  - 서비스 단계에서 requestDto 그대로 활용

- **to-be**
  - 추상화를 통해 비즈니스 로직 코드 가독성 향상
  - success base 코드 사용
  - valid 중복 검사 제거
  - 서비스 단계에서 requestDto -> entity로 변환해 활용

## 코멘트
- login 관련해서는 dto를 entity로 변환해서 사용하는게 맞을지, 그대로 가면 될지 고민입니다. 필드 두개만 활용하다보니 entity로 변환하는 작업이 좀 더 복잡하게 느껴져서요..!
