### PR TITLE
feat: menu - 메뉴 수정 API 구현 #57

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
@@ -1,8 +1,9 @@
 package com.ioteam.order_management_platform.global.success;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
@@ -39,6 +40,7 @@ public enum SuccessCode {
 	MENU_LIST_INFO(HttpStatus.OK, "메뉴 목록을 조회하는데에 성공하였습니다.", "S_MENU_LIST_INFO"),
 	MENU_DETAIL_INFO(HttpStatus.OK, "메뉴 상세정보를 조회하는데에 성공하였습니다.", "S_MENU_LIST_INFO"),
 	MENU_CREATE(HttpStatus.OK, "메뉴를 성공적으로 등록하였습니다.", "S_MENU_LIST_INFO"),
+	MENU_MODIFY(HttpStatus.OK, "메뉴를 성공적으로 수정하였습니다.", "S_MENU_MODIFY"),
 
 	// payment
 

--- a/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,6 +18,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
 import com.ioteam.order_management_platform.global.success.SuccessCode;
 import com.ioteam.order_management_platform.menu.dto.req.CreateMenuRequestDto;
+import com.ioteam.order_management_platform.menu.dto.req.UpdateMenuRequestDto;
 import com.ioteam.order_management_platform.menu.dto.res.MenuListResponseDto;
 import com.ioteam.order_management_platform.menu.dto.res.MenuResponseDto;
 import com.ioteam.order_management_platform.menu.service.MenuService;
@@ -60,5 +62,14 @@ public class MenuController {
 	public ResponseEntity<CommonResponse<MenuResponseDto>> getMenuDetail(@PathVariable("menu_id") UUID menuId) {
 		MenuResponseDto responseDto = menuService.getMenuDetail(menuId);
 		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.MENU_DETAIL_INFO, responseDto));
+	}
+
+	@Operation(summary = "상품 수정", description = "상품 수정은 OWNER와 MANAGER만 가능")
+	@PatchMapping("/{menu_id}")
+	@PreAuthorize("hasAnyRole('OWNER', 'MANAGER')")
+	public ResponseEntity<CommonResponse<MenuResponseDto>> modifyMenu(@PathVariable("menu_id") UUID menuId,
+		@RequestBody @Validated UpdateMenuRequestDto requestDto) {
+		MenuResponseDto responseDto = menuService.modifyMenu(menuId, requestDto);
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.MENU_MODIFY, responseDto));
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/menu/dto/req/UpdateMenuRequestDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/dto/req/UpdateMenuRequestDto.java
@@ -1,0 +1,24 @@
+package com.ioteam.order_management_platform.menu.dto.req;
+
+import java.math.BigDecimal;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateMenuRequestDto {
+
+	@Length(min = 1, max = 100)
+	private String rmName;
+	@Min(value = 0)
+	private BigDecimal rmPrice;
+	private String rmImageUrl;
+	@Length(max = 100)
+	private String rmDescription;
+	private Boolean isPublic;
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/menu/entity/Menu.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/entity/Menu.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.hibernate.annotations.ColumnDefault;
 
 import com.ioteam.order_management_platform.global.entity.BaseEntity;
+import com.ioteam.order_management_platform.menu.dto.req.UpdateMenuRequestDto;
 import com.ioteam.order_management_platform.restaurant.entity.Restaurant;
 
 import jakarta.persistence.Column;
@@ -46,5 +47,19 @@ public class Menu extends BaseEntity {
 	private String rmDescription;
 	@ColumnDefault("true")
 	private Boolean isPublic;
+
+	public Menu updateMenu(UpdateMenuRequestDto requestDto) {
+		if (requestDto.getRmName() != null)
+			this.rmName = requestDto.getRmName();
+		if (requestDto.getRmPrice() != null)
+			this.rmPrice = requestDto.getRmPrice();
+		if (requestDto.getRmImageUrl() != null)
+			this.rmImageUrl = requestDto.getRmImageUrl();
+		if (requestDto.getRmDescription() != null)
+			this.rmDescription = requestDto.getRmDescription();
+		if (requestDto.getIsPublic() != null)
+			this.isPublic = requestDto.getIsPublic();
+		return this;
+	}
 
 }

--- a/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ioteam.order_management_platform.global.exception.CustomApiException;
 import com.ioteam.order_management_platform.menu.dto.req.CreateMenuRequestDto;
+import com.ioteam.order_management_platform.menu.dto.req.UpdateMenuRequestDto;
 import com.ioteam.order_management_platform.menu.dto.res.MenuListResponseDto;
 import com.ioteam.order_management_platform.menu.dto.res.MenuResponseDto;
 import com.ioteam.order_management_platform.menu.entity.Menu;
@@ -40,6 +41,7 @@ public class MenuService {
 	public MenuListResponseDto getAllMenus(UUID restaurantId) {
 		validRestaurantExist(restaurantId);
 		List<Menu> menuList = menuRepository.findByRestaurant_ResId(restaurantId);
+		// TODO: isPublic 조회 조건에 추가
 		return MenuListResponseDto.of(menuList);
 	}
 
@@ -47,6 +49,14 @@ public class MenuService {
 		Menu menu = menuRepository.findById(menuId)
 			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_MENU));
 		return MenuResponseDto.fromEntity(menu);
+	}
+
+	@Transactional
+	public MenuResponseDto modifyMenu(UUID menuId, UpdateMenuRequestDto requestDto) {
+		Menu menu = menuRepository.findById(menuId)
+			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_MENU));
+		Menu updatedMenu = menu.updateMenu(requestDto);
+		return MenuResponseDto.fromEntity(updatedMenu);
 	}
 
 	private void validRestaurantExist(UUID restaurantId) {

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -13,7 +13,7 @@ VALUES (now(), now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, 'd2ed72d8-09
 
 -- p_restaurant_menu 테이블 목데이터 추가
 INSERT INTO p_restaurant_menu (is_public, rm_price, created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, res_id, rm_id, rm_description, rm_name, rm_image_url)
-VALUES (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', "imageurl");
+VALUES (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', 'imageurl');
 
 -- p_order 테이블 목데이터 추가
 INSERT INTO p_order

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -13,7 +13,7 @@ VALUES (now(), now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, 'd2ed72d8-09
 
 -- p_restaurant_menu 테이블 목데이터 추가
 INSERT INTO p_restaurant_menu (is_public, rm_price, created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, res_id, rm_id, rm_description, rm_name, rm_image_url)
-VALUES (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', null);
+VALUES (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', "imageurl");
 
 -- p_order 테이블 목데이터 추가
 INSERT INTO p_order


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**
  - data.sql 메뉴 image url 데이터 값 추가
  - Menu 엔티티에서 modify 메서드 구현
  - PATCH 메서드 + null 체크로 로직 작성

## 코멘트
-  수정하려는 OWNER가 해당 메뉴가 포함된 가게의 주인이 맞는지 에 대한 검증 필요성에 대해 고민중입니다. 
수정 버튼이 OWNER와 MANAGER 한테만 보일 것이기 때문에  수정 로직에서는 검증이 필요한가 싶습니다. 혹시나 의견이  있으시다면 말씀 부탁드립낟!

- 또한, 조회할 때 수정 버튼이 해당 OWNER한테만 보여야할텐데 이 부분을 처리하는 과정에서 
1) 서버가 주인 여부 필드를 두어서 응답을 해주는 방식이 좋을지,
2) OWNER id 도 함께 보내면 클라이언트가 로그인한 사용자와 비교하여 화면에 처리하는 방식이 좋을지도 고민 중입니다.

- 또한, 메뉴 조회  api에서 OWNER에게는 isPublic 상관없이 모든 메뉴가 조회되고, CUSTOMER에게는 isPublic == true 인 부분만 보여줘야 하는데 빼먹어서 추가할 예정입니다!
