### PR TITLE
feat: Category - 카테고리 소프트삭제 API 구현 #74

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/category/controller/CategoryController.java
+++ b/src/main/java/com/ioteam/order_management_platform/category/controller/CategoryController.java
@@ -9,6 +9,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -106,6 +107,19 @@ public class CategoryController {
 		return ResponseEntity
 			.ok()
 			.body(new CommonResponse<>(SuccessCode.CATEGORY_MODIFY, categoryResponseDto));
+	}
+
+	@DeleteMapping("/categories/{rcId}")
+	@Operation(summary = "카테고리 소프트 삭제", description = "카테고리 삭제는 'MANAGER'만 가능")
+	public ResponseEntity<CommonResponse<CategoryResponseDto>> softDeleteCategory(
+		@PathVariable UUID rcId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		categoryService.softDeleteCategory(rcId, userDetails);
+
+		return ResponseEntity
+			.ok()
+			.body(new CommonResponse<>(SuccessCode.CATEGORY_DELETE, null));
 	}
 
 }

--- a/src/main/java/com/ioteam/order_management_platform/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ioteam/order_management_platform/category/repository/CategoryRepository.java
@@ -14,4 +14,6 @@ public interface CategoryRepository extends JpaRepository<Category, UUID> {
 	Optional<Category> findByRcIdAndDeletedAtIsNull(UUID rcId);
 
 	Page<Category> findAllByDeletedAtIsNull(Pageable pageable);
+
+	boolean existsByRcNameAndDeletedAtIsNull(String rcName);
 }

--- a/src/main/java/com/ioteam/order_management_platform/category/service/CategoryService.java
+++ b/src/main/java/com/ioteam/order_management_platform/category/service/CategoryService.java
@@ -123,4 +123,19 @@ public class CategoryService {
 
 		return CategoryResponseDto.fromCategory(targetCategory);
 	}
+
+	@Transactional
+	public void softDeleteCategory(UUID rcId, UserDetailsImpl userDetails) {
+
+		boolean isAuthorized = hasManagerOrOwnerRole(userDetails);
+
+		if (!isAuthorized) {
+			throw new CustomApiException(CategoryException.NOT_AUTHORIZED_ROLE);
+		}
+
+		Category targetCategory = categoryRepository.findByRcIdAndDeletedAtIsNull(rcId)
+			.orElseThrow(() -> new CustomApiException(CategoryException.CATEGORY_NOT_FOUND));
+
+		targetCategory.softDelete(userDetails.getUserId());
+	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/category/service/CategoryService.java
+++ b/src/main/java/com/ioteam/order_management_platform/category/service/CategoryService.java
@@ -56,6 +56,16 @@ public class CategoryService {
 			throw new CustomApiException(CategoryException.EMPTY_CATEGORY_NAME);
 		}
 
+		// 삭제되었는데 다시 부활시키는 방향도?
+		if (categoryRepository.existsByRcNameAndDeletedAtIsNull(
+			categoryRequestDto
+				.getRcName()
+				.trim()
+		)
+		) {
+			throw new CustomApiException(CategoryException.DUPLICATE_CATEGORY_NAME);
+		}
+
 		Category category = CreateCategoryRequestDto.toCategory(categoryRequestDto);
 		Category savedCategory = categoryRepository.save(category);
 


### PR DESCRIPTION
## 이슈번호
#74 

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**
  - 카테고리 소프트 삭제 API 구현

## 코멘트
- global BaseEntity에 공용으로 만들어 둔 softDelete메서드 사용했습니다
