### PR TITLE
feat: menu - 메뉴 조회 시 권한과 가게 주인 여부에 따른 조회 조건 추가 #75

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
@@ -54,8 +54,9 @@ public class MenuController {
 	@Operation(summary = "특정 가게 상품 전체 조회")
 	@GetMapping("restaurant/{restaurant_id}")
 	public ResponseEntity<CommonResponse<MenuListResponseDto>> getAllMenu(
-		@PathVariable("restaurant_id") UUID restaurantId) {
-		MenuListResponseDto responseDto = menuService.getAllMenus(restaurantId);
+		@PathVariable("restaurant_id") UUID restaurantId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		MenuListResponseDto responseDto = menuService.getAllMenus(restaurantId, userDetails);
 		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.MENU_LIST_INFO, responseDto));
 	}
 

--- a/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuCustomRepository.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuCustomRepository.java
@@ -1,0 +1,11 @@
+package com.ioteam.order_management_platform.menu.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.menu.entity.Menu;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+public interface MenuCustomRepository {
+	List<Menu> findMenusByResIdAndRole(UUID resId, UserDetailsImpl userDetails);
+}

--- a/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuCustomRepositoryImpl.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuCustomRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.ioteam.order_management_platform.menu.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.menu.entity.Menu;
+import com.ioteam.order_management_platform.menu.entity.QMenu;
+import com.ioteam.order_management_platform.restaurant.entity.QRestaurant;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MenuCustomRepositoryImpl implements MenuCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<Menu> findMenusByResIdAndRole(UUID resId, UserDetailsImpl userDetails) {
+		QMenu menu = QMenu.menu;
+		UserRoleEnum role = userDetails.getRole();
+		UUID userId = userDetails.getUserId();
+		boolean isOwner = isOwner(userId, resId);
+
+		BooleanExpression condition = menu.restaurant.resId.eq(resId);
+
+		// role과 OWNER id 일치 여부에 따른 condition 추가
+		if (role.equals(UserRoleEnum.CUSTOMER) || (role.equals(UserRoleEnum.OWNER) && !isOwner)) {
+			condition = condition.and(menu.isPublic.eq(true));
+		}
+
+		return jpaQueryFactory.selectFrom(menu).where(condition).fetch();
+	}
+
+	public boolean isOwner(UUID userId, UUID resId) {
+		QRestaurant restaurant = QRestaurant.restaurant;
+		log.info("Checking if restaurant is owner of user {}", userId);
+		Integer owner = jpaQueryFactory.selectOne()
+			.from(restaurant)
+			.where(restaurant.resId.eq(resId).and(restaurant.owner.userId.eq(userId)))
+			.fetchFirst();
+		return owner != null;
+	}
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuRepository.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/repository/MenuRepository.java
@@ -1,6 +1,5 @@
 package com.ioteam.order_management_platform.menu.repository;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,8 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.ioteam.order_management_platform.menu.entity.Menu;
 
-public interface MenuRepository extends JpaRepository<Menu, UUID> {
-	List<Menu> findByRestaurant_ResId(UUID restaurantId);
+public interface MenuRepository extends JpaRepository<Menu, UUID>, MenuCustomRepository {
 
 	@Query("Select u.userId from User u join Restaurant r on r.owner.userId = u.userId join Menu m on m.restaurant.resId = r.resId where m.rmId = :rmId ")
 	UUID getRestaurantOwnerId(@Param("rmId") UUID rmId);

--- a/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
@@ -40,10 +40,9 @@ public class MenuService {
 		return MenuResponseDto.fromEntity(savedMenu);
 	}
 
-	public MenuListResponseDto getAllMenus(UUID restaurantId) {
-		validRestaurantExist(restaurantId);
-		List<Menu> menuList = menuRepository.findByRestaurant_ResId(restaurantId);
-		// TODO: isPublic 조회 조건에 추가
+	public MenuListResponseDto getAllMenus(UUID resId, UserDetailsImpl userDetails) {
+		validRestaurantExist(resId);
+		List<Menu> menuList = menuRepository.findMenusByResIdAndRole(resId, userDetails);
 		return MenuListResponseDto.of(menuList);
 	}
 

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -21,7 +21,10 @@ VALUES
 
 -- p_restaurant_menu 테이블 목데이터 추가
 INSERT INTO p_restaurant_menu (is_public, rm_price, created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, res_id, rm_id, rm_description, rm_name, rm_image_url)
-VALUES (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', 'imageurl');
+VALUES
+    (true, 8500, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '439f222b-0cbb-4600-a989-e7fdabf120d5'::uuid, '맛있는 열정 가득 파스타입니다.', '열파르타', 'imageurl'),
+    (false, 1000000, now(), null, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '2c48e6c8-56c5-47f9-bd6f-af01647a0d1b'::uuid, '매니저랑 가게 오너만 볼 수 있는 메뉴입니다.', '우주 최강 맛있는 씨크릿 화덕 피자 레시피', 'pizza');
+
 
 -- p_order 테이블 목데이터 추가
 INSERT INTO p_order


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용

- **to-be**
  - 메뉴 데이터 data.sql에 추가 작성
  - 조회 조건 추가 로직 작성


## 코멘트
- 가게 주인 여부 확인 로직이 다른  api의 로직과 중복되는 부분이라서 어떻게 리팩토링할지는 고민 중에 있습니다!
