### PR TITLE
feat: menu - 단건 메뉴 숨김 처리 api 구현 #95

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/controller/MenuController.java
@@ -75,4 +75,13 @@ public class MenuController {
 		MenuResponseDto responseDto = menuService.modifyMenu(menuId, requestDto, userDetails);
 		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.MENU_MODIFY, responseDto));
 	}
+
+	@Operation(summary = "상품 숨김 처리", description = "상품 숨김처리는 OWNER와 MANAGER만 가능")
+	@PatchMapping("/{menu_id}/hidden")
+	@PreAuthorize("hasAnyRole('OWNER', 'MANAGER')")
+	public ResponseEntity<CommonResponse<MenuResponseDto>> hiddenMenu(@PathVariable("menu_id") UUID menuId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		MenuResponseDto responseDto = menuService.hiddenMenu(menuId, userDetails);
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.MENU_MODIFY, responseDto));
+	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/menu/entity/Menu.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/entity/Menu.java
@@ -62,4 +62,9 @@ public class Menu extends BaseEntity {
 		return this;
 	}
 
+	public Menu hiddenMenu() {
+		this.isPublic = !isPublic;
+		return this;
+	}
+
 }

--- a/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
+++ b/src/main/java/com/ioteam/order_management_platform/menu/service/MenuService.java
@@ -62,6 +62,15 @@ public class MenuService {
 		return MenuResponseDto.fromEntity(updatedMenu);
 	}
 
+	@Transactional
+	public MenuResponseDto hiddenMenu(UUID menuId, UserDetailsImpl userDetails) {
+		Menu menu = menuRepository.findById(menuId)
+			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_MENU));
+		hasModificationPermission(userDetails, menu);
+		Menu hiddenMenu = menu.hiddenMenu();
+		return MenuResponseDto.fromEntity(hiddenMenu);
+	}
+
 	private void hasModificationPermission(UserDetailsImpl userDetails, Menu menu) {
 		UserRoleEnum role = userDetails.getRole();
 		if (role.equals(UserRoleEnum.MANAGER)) {


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **to-be**
  - 메뉴 id에 따른 isPublic 필드값 변경

## 코멘트
- api 설계 시에는 메뉴 숨김 기능을 통해서 isPublic 상태만 변경해주는 api가 따로 필요하다고 생각했는데 구현하다보니 메뉴 수정과 로직이 매우 흡사하여 api 의 필요성에 대해 고민하게 되었습니다.
- 그리고, 숨김 기능의 경우 http 응답값을 ok로 보내야할지 noContent로 할지도 고민했습니다. 많은 의견 부탁드립니다..!
