### PR TITLE
feat : 결제 - 상태 변경 api #102

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
@@ -50,6 +50,7 @@ public enum SuccessCode {
 	PAYMENT_CREATE(HttpStatus.CREATED, "결제가 성공적으로 요청되었습니다.", "S_PAYMENT_CREATE"),
 	PAYMENT_SEARCH(HttpStatus.OK, "결제가 성공적으로 조회되었습니다.", "S_PAYMENT_SEARCH"),
 	PAYMENT_DELETE(HttpStatus.OK, "결제가 성공적으로 삭제되었습니다.", "S_PAYMENT_DELETE"),
+	PAYMENT_STATUS_CHANGED(HttpStatus.OK, "결제 상태가 성공적으로 변경되었습니다.", " S_PAYMENT_STATUS_CHANGED"),
 	// ai
 
 	// restaurant

--- a/src/main/java/com/ioteam/order_management_platform/payment/controller/PaymentController.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/controller/PaymentController.java
@@ -11,10 +11,12 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
@@ -27,6 +29,7 @@ import com.ioteam.order_management_platform.payment.dto.req.CustomerPaymentSearc
 import com.ioteam.order_management_platform.payment.dto.req.OwnerPaymentSearchCondition;
 import com.ioteam.order_management_platform.payment.dto.res.AdminPaymentResponseDto;
 import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
+import com.ioteam.order_management_platform.payment.entity.PaymentStatusEnum;
 import com.ioteam.order_management_platform.payment.service.PaymentService;
 import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
 
@@ -113,4 +116,15 @@ public class PaymentController {
 		paymentService.softDeletePayment(paymentId, userDetails);
 		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.PAYMENT_DELETE, null));
 	}
+
+	@Operation(summary = "결제 상태 변경", description = "결제 상태 변경은 'MANAGER','MASTER' 만 가능")
+	@PreAuthorize("hasAnyRole('MANAGER','MASTER')")
+	@PatchMapping("/{paymentId}/status")
+	public ResponseEntity<CommonResponse<PaymentResponseDto>> changePaymentStatus(
+		@PathVariable UUID paymentId,
+		@RequestParam PaymentStatusEnum newStatus) {
+		PaymentResponseDto responseDto = paymentService.changePaymentStatus(paymentId, newStatus);
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.PAYMENT_STATUS_CHANGED, responseDto));
+	}
+
 }

--- a/src/main/java/com/ioteam/order_management_platform/payment/entity/Payment.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/entity/Payment.java
@@ -48,7 +48,7 @@ public class Payment extends BaseEntity {
 	private String paymentNumber;
 
 	@Enumerated(EnumType.STRING)
-	@Column(length = 20, nullable = false)
+	@Column(length = 10, nullable = false)
 	private PaymentStatusEnum paymentStatus;
 
 	@Column
@@ -56,4 +56,17 @@ public class Payment extends BaseEntity {
 
 	@Column
 	private LocalDateTime paymentFailedAt;
+
+	public void setPaymentStatus(PaymentStatusEnum newStatus) {
+		// 결제 상태가 'PENDING'에서 'COMPLETED'로 변경될 때 결제 완료 시간을 설정
+		if (newStatus == PaymentStatusEnum.COMPLETED && this.paymentStatus != PaymentStatusEnum.COMPLETED) {
+			this.paymentCompletedAt = LocalDateTime.now();
+		}
+		// 결제 상태가 'PENDING'에서 'FAILED'로 변경될 때 결제 실패 시간을 설정
+		if (newStatus == PaymentStatusEnum.FAILED && this.paymentStatus != PaymentStatusEnum.FAILED) {
+			this.paymentFailedAt = LocalDateTime.now();
+		}
+		// 상태 변경
+		this.paymentStatus = newStatus;
+	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/payment/entity/PaymentStatusEnum.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/entity/PaymentStatusEnum.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 public enum PaymentStatusEnum {
 	PENDING,
 	COMPLETED,
-	FAILED,
+	FAILED, // 결제 실패 시 재주문을 통해 결제해야 함. 한번 FAILED 되면 바뀌지 않게끔 설정
 	CANCELLED //5분 안에 주문이 취소되는데, 결제가 이미 들어가 있는 상태일때
 }

--- a/src/main/java/com/ioteam/order_management_platform/payment/exception/PaymentException.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/exception/PaymentException.java
@@ -14,6 +14,7 @@ public enum PaymentException implements ExceptionType {
 	UNAUTHORIZED_REQ(HttpStatus.FORBIDDEN, "권한이 없는 요청입니다.", "E_UNAUTHORIZED_REQ"),
 	INVALID_USER(HttpStatus.FORBIDDEN, "현재 로그인한 사용자가 해당 결제를 진행할 권한이 없습니다.", "E_INVALID_USER"),
 	RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 정보가 조회되지 않습니다.", "E_RESTAURANT_NOT_FOUND"),
+	PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 정보가 조회되지 않습니다.", "E_PAYMENT_NOT_FOUND"),
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/PaymentService.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/PaymentService.java
@@ -18,6 +18,7 @@ import com.ioteam.order_management_platform.payment.dto.req.OwnerPaymentSearchCo
 import com.ioteam.order_management_platform.payment.dto.res.AdminPaymentResponseDto;
 import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
 import com.ioteam.order_management_platform.payment.entity.Payment;
+import com.ioteam.order_management_platform.payment.entity.PaymentStatusEnum;
 import com.ioteam.order_management_platform.payment.exception.PaymentException;
 import com.ioteam.order_management_platform.payment.repository.PaymentRepository;
 import com.ioteam.order_management_platform.restaurant.entity.Restaurant;
@@ -124,5 +125,18 @@ public class PaymentService {
 			.orElseThrow(() -> new CustomApiException(PaymentException.INVALID_PAYMENT_ID));
 
 		payment.softDelete(userDetails.getUserId());
+	}
+
+	@Transactional
+	public PaymentResponseDto changePaymentStatus(UUID paymentId, PaymentStatusEnum newStatus) {
+		Payment payment = paymentRepository.findByPaymentIdAndDeletedAtIsNull(paymentId)
+			.orElseThrow(() -> new CustomApiException(PaymentException.PAYMENT_NOT_FOUND));
+		if (payment.getPaymentStatus() == PaymentStatusEnum.PENDING && payment.getPaymentStatus() != newStatus) {
+			payment.setPaymentStatus(newStatus);
+			Payment updatedPayment = paymentRepository.save(payment);
+			return PaymentResponseDto.from(updatedPayment);
+		} else {
+			throw new CustomApiException(PaymentException.PAYMENT_ALREADY_COMPLETED);
+		}
 	}
 }


### PR DESCRIPTION
- 결제 상태 변경 api 작성

## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
- **to-be**
  - 결제 상태를 PENDING 에서 COMPLETE 또는 FAILED로 변경하는 api(PG사에서 변경한다고 생각)

## 코멘트
- PENDING에서 CANCELED 되는 로직은 ORDER쪽에서 주문을 취소햇을 때, 만약에 주문에 대한 결제가 이미 들어갖고 5분 이내에 취소가 된다면 CANCELED 되어야 하지 않을까 생각이 듭니다!
- setPaymentStatus 메소드를 통해 결제 완료 혹은 실패 시간에 대해 설정해주는 로직을 구현하였는데 괜찮을지 모르겠네요!!
