### PR TITLE
Feat/#109 AI 메뉴 설명 추천 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,10 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
 
+    // AI 요청
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'io.projectreactor:reactor-test'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
@@ -1,0 +1,38 @@
+package com.ioteam.order_management_platform.ai.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ioteam.order_management_platform.ai.dto.req.RecommendDesRequestDto;
+import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
+import com.ioteam.order_management_platform.ai.service.AiService;
+import com.ioteam.order_management_platform.global.dto.CommonResponse;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+@Tag(name = "AI", description = "AI API")
+public class AiController {
+
+	private final AiService aiService;
+
+	@Operation(summary = "AI 상품 설명 추천 기능", description = "가게 주인이 작성한 5개의 키워드와 가게 정보와 메뉴 정보로 상품 설명 문구를 추천합니다.")
+	@GetMapping("/menu-description")
+	@PreAuthorize("hasAnyRole('OWNER', 'MANAGER')")
+	public ResponseEntity<CommonResponse<AnswerAiResponseDto>> getAiMenuDescription(
+		@RequestBody RecommendDesRequestDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		AnswerAiResponseDto responseDto = aiService.recommendMenuDescription(userDetails, requestDto);
+		return ResponseEntity.ok(new CommonResponse<>("code", responseDto));
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
@@ -3,7 +3,7 @@ package com.ioteam.order_management_platform.ai.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,7 +27,7 @@ public class AiController {
 	private final AiService aiService;
 
 	@Operation(summary = "AI 상품 설명 추천 기능", description = "가게 주인이 작성한 5개의 키워드와 가게 정보와 메뉴 정보로 상품 설명 문구를 추천합니다.")
-	@GetMapping("/menu-description")
+	@PostMapping("/menu-description")
 	@PreAuthorize("hasAnyRole('OWNER', 'MANAGER')")
 	public ResponseEntity<CommonResponse<AnswerAiResponseDto>> getAiMenuDescription(
 		@RequestBody RecommendDesRequestDto requestDto,

--- a/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/controller/AiController.java
@@ -3,6 +3,7 @@ package com.ioteam.order_management_platform.ai.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import com.ioteam.order_management_platform.ai.dto.req.RecommendDesRequestDto;
 import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
 import com.ioteam.order_management_platform.ai.service.AiService;
 import com.ioteam.order_management_platform.global.dto.CommonResponse;
+import com.ioteam.order_management_platform.global.success.SuccessCode;
 import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,9 +32,9 @@ public class AiController {
 	@PostMapping("/menu-description")
 	@PreAuthorize("hasAnyRole('OWNER', 'MANAGER')")
 	public ResponseEntity<CommonResponse<AnswerAiResponseDto>> getAiMenuDescription(
-		@RequestBody RecommendDesRequestDto requestDto,
+		@RequestBody @Validated RecommendDesRequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		AnswerAiResponseDto responseDto = aiService.recommendMenuDescription(userDetails, requestDto);
-		return ResponseEntity.ok(new CommonResponse<>("code", responseDto));
+		return ResponseEntity.ok(new CommonResponse<>(SuccessCode.AI_CREATE_MENU_DESCRIPTION, responseDto));
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/dto/req/RecommendDesRequestDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/dto/req/RecommendDesRequestDto.java
@@ -1,15 +1,17 @@
 package com.ioteam.order_management_platform.ai.dto.req;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import org.hibernate.validator.constraints.Length;
 
+import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
 import com.ioteam.order_management_platform.ai.entity.AIResponse;
 import com.ioteam.order_management_platform.user.entity.User;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,15 +26,17 @@ public class RecommendDesRequestDto {
 	@NotNull
 	@Length(min = 1, max = 100)
 	private String rmName;
-	private List<String> keywords = new ArrayList<>();
+	@Size(max = 5)
+	@Valid
+	private List<@Length(max = 10) String> keywords;
 
-	public static AIResponse toEntity(User user, String question, String aiAnswer) {
+	public static AIResponse toEntity(User user, String question, AnswerAiResponseDto aiAnswer) {
 		return AIResponse
 			.builder()
 			.user(user)
 			.arQuestion(question)
-			.arAnswer(aiAnswer)
-			// .arModel()
+			.arAnswer(aiAnswer.getArAnswer())
+			.arModel(aiAnswer.getArModel())
 			.build();
 	}
 

--- a/src/main/java/com/ioteam/order_management_platform/ai/dto/req/RecommendDesRequestDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/dto/req/RecommendDesRequestDto.java
@@ -1,0 +1,39 @@
+package com.ioteam.order_management_platform.ai.dto.req;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.validator.constraints.Length;
+
+import com.ioteam.order_management_platform.ai.entity.AIResponse;
+import com.ioteam.order_management_platform.user.entity.User;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class RecommendDesRequestDto {
+
+	@NotNull
+	private UUID resId; // resId 받아서 가게 이름, 가게 카테고리 조회
+	@NotNull
+	@Length(min = 1, max = 100)
+	private String rmName;
+	private List<String> keywords = new ArrayList<>();
+
+	public static AIResponse toEntity(User user, String question, String aiAnswer) {
+		return AIResponse
+			.builder()
+			.user(user)
+			.arQuestion(question)
+			.arAnswer(aiAnswer)
+			// .arModel()
+			.build();
+	}
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/dto/res/AnswerAiResponseDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/dto/res/AnswerAiResponseDto.java
@@ -13,13 +13,28 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AnswerAiResponseDto {
 	private UUID arId;
+	private String arQuestion;
 	private String arAnswer;
+	private String arModel;
 
 	public static AnswerAiResponseDto of(AIResponse aiResponse) {
 		return AnswerAiResponseDto
 			.builder()
 			.arId(aiResponse.getArId())
+			.arQuestion(aiResponse.getArQuestion())
 			.arAnswer(aiResponse.getArAnswer())
+			.arModel(aiResponse.getArModel())
+			.build();
+	}
+
+	public static AnswerAiResponseDto fromGemini(GeminiResponseDto responseDto) {
+		return AnswerAiResponseDto
+			.builder()
+			.arAnswer(responseDto.getCandidates().get(0)
+				.getContent()
+				.getParts().get(0)
+				.getText().replace("\n", ""))
+			.arModel(responseDto.getModelVersion())
 			.build();
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/dto/res/AnswerAiResponseDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/dto/res/AnswerAiResponseDto.java
@@ -1,0 +1,25 @@
+package com.ioteam.order_management_platform.ai.dto.res;
+
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.ai.entity.AIResponse;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AnswerAiResponseDto {
+	private UUID arId;
+	private String arAnswer;
+
+	public static AnswerAiResponseDto of(AIResponse aiResponse) {
+		return AnswerAiResponseDto
+			.builder()
+			.arId(aiResponse.getArId())
+			.arAnswer(aiResponse.getArAnswer())
+			.build();
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/dto/res/GeminiResponseDto.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/dto/res/GeminiResponseDto.java
@@ -1,0 +1,29 @@
+package com.ioteam.order_management_platform.ai.dto.res;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GeminiResponseDto {
+	private List<Candidate> candidates;
+	private String modelVersion;
+
+	@Getter
+	public static class Candidate {
+		private Content content;
+
+		@Getter
+		public static class Content {
+			private List<Part> parts;
+
+			@Getter
+			public static class Part {
+				private String text;
+			}
+		}
+
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
@@ -1,0 +1,44 @@
+package com.ioteam.order_management_platform.ai.entity;
+
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.global.entity.BaseEntity;
+import com.ioteam.order_management_platform.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_ai_response")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class AIResponse extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private UUID arId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+	@Column(length = 1000, nullable = false)
+	private String arQuestion;
+	@Column(length = 50, nullable = false)
+	private String arAnswer;
+	@Column(length = 100, nullable = false)
+	private String arModel;
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
@@ -38,7 +38,6 @@ public class AIResponse extends BaseEntity {
 	private String arQuestion;
 	@Column(length = 100, nullable = false)
 	private String arAnswer;
-	@Column(length = 100)
 	private String arModel;
 
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/entity/AIResponse.java
@@ -36,9 +36,9 @@ public class AIResponse extends BaseEntity {
 	private User user;
 	@Column(length = 1000, nullable = false)
 	private String arQuestion;
-	@Column(length = 50, nullable = false)
-	private String arAnswer;
 	@Column(length = 100, nullable = false)
+	private String arAnswer;
+	@Column(length = 100)
 	private String arModel;
 
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/exception/AIException.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/exception/AIException.java
@@ -1,0 +1,36 @@
+package com.ioteam.order_management_platform.ai.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.ioteam.order_management_platform.global.exception.type.ExceptionType;
+
+public enum AIException implements ExceptionType {
+
+	INVALID_AI_RESPONSE(HttpStatus.BAD_REQUEST, "AI 응답이 올바르지 않습니다.", "E_INVALID_AI_RESPONSE"),
+	AI_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "AI 서비스 연동 중 오류가 발생했습니다.", "E_AI_SERVICE_UNAVAILABLE");
+
+	private final HttpStatus status;
+	private final String message;
+	private final String errorCode;
+
+	AIException(HttpStatus status, String message, String errorCode) {
+		this.status = status;
+		this.message = message;
+		this.errorCode = errorCode;
+	}
+
+	@Override
+	public HttpStatus getStatus() {
+		return this.status;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.message;
+	}
+
+	@Override
+	public String getErrorCode() {
+		return this.errorCode;
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/repository/AiRepository.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/repository/AiRepository.java
@@ -1,0 +1,10 @@
+package com.ioteam.order_management_platform.ai.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ioteam.order_management_platform.ai.entity.AIResponse;
+
+public interface AiRepository extends JpaRepository<AIResponse, UUID> {
+}

--- a/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
@@ -7,11 +7,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ioteam.order_management_platform.ai.dto.req.RecommendDesRequestDto;
 import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
+import com.ioteam.order_management_platform.ai.dto.res.GeminiResponseDto;
 import com.ioteam.order_management_platform.ai.entity.AIResponse;
 import com.ioteam.order_management_platform.ai.repository.AiRepository;
 import com.ioteam.order_management_platform.global.exception.CustomApiException;
@@ -46,33 +44,30 @@ public class AiService {
 
 		// 사용자 유효성 검증 (owner이면서 해당 가게 주인인지? 필요한가
 		User user = userDetails.getUser();
-		// 받아온 resId로 가게명, 음식점 카테고리 조회
+
 		Restaurant restaurant = restaurantRepository.findByResIdAndDeletedAtIsNull(requestDto.getResId())
 			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_RESTAURANT_ID));
 
-		// // 가게명, 메뉴명, 음식점 카테고리와 OWNER의 입력 키워드로 상품 설명 추천 요청
 		String question = "가게 이름: " + restaurant.getResName()
 			+ ", 메뉴 이름: " + requestDto.getRmName()
-			+ ", 가게 카테고리: " + restaurant.getCategory();
+			+ ", 가게 카테고리: " + restaurant.getCategory().getRcName()
+			+ ", 키워드: " + requestDto.getKeywords().toString();
 
-		// // 입력 텍스트의 글자수를 제한 (키워드는 10자씩? 키워드 리스트로 받아올 예정인데 리스트 내부 데이터도 제한 가능한가
+		question += " 주어진 정보를 기반으로 <메뉴 설명> 내용을 추천해줘. 답변을 최대한 간결하게 50자 이하로 해줘.";
 
-		// // 실제 요청 텍스트 마지막에 “답변을 최대한 간결하게 50자 이하로” 라는 텍스트를 요청시에 삽입하여 사용량을 줄이는 처리를 추가
-		question += "위의 내용을 기반으로 <메뉴 설명> 내용을 추천해줘. 답변을 최대한 간결하게 50자 이하로 해줘.";
-
+		System.out.println(question);
 		// API 호출
-		String aiAnswer = requestGemini(question);
-		// OWNER의 입력 키워드의 경우 최대 5개
+		AnswerAiResponseDto aiAnswer = requestGemini(question);
 
-		// AI의 응답의 문장만 DB에 저장
+		// AI의 응답 문장만 DB에 저장
 		AIResponse aiResponse = RecommendDesRequestDto.toEntity(user, question, aiAnswer);
 		AIResponse response = aiRepository.save(aiResponse);
 
 		return AnswerAiResponseDto.of(response);
 	}
 
-	private String requestGemini(String question) {
-
+	private AnswerAiResponseDto requestGemini(String question) {
+		//TODO: exceptio 처리
 		Map<String, Object> requestBody = Map.of(
 			"contents", new Object[] {
 				Map.of("parts", new Object[] {
@@ -81,25 +76,14 @@ public class AiService {
 			}
 		);
 
-		String aiAnswer = webClient.post()
+		GeminiResponseDto aiAnswer = webClient.post()
 			.uri(geminiApiUrl + geminiApiKey)
 			.header("Content-Type", "application/json")
 			.bodyValue(requestBody)
 			.retrieve()
-			.bodyToMono(String.class)
+			.bodyToMono(GeminiResponseDto.class)
 			.block();
 
-		try {
-			JsonNode root = new ObjectMapper().readTree(aiAnswer);
-			return root.get("candidates")
-				.get(0)
-				.get("content")
-				.get("parts")
-				.get(0)
-				.get("text")
-				.asText();
-		} catch (JsonProcessingException e) {
-			throw new CustomApiException("AI 응답 파싱 중 오류 발생");
-		}
+		return AnswerAiResponseDto.fromGemini(aiAnswer);
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
@@ -11,6 +11,7 @@ import com.ioteam.order_management_platform.ai.dto.req.RecommendDesRequestDto;
 import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
 import com.ioteam.order_management_platform.ai.dto.res.GeminiResponseDto;
 import com.ioteam.order_management_platform.ai.entity.AIResponse;
+import com.ioteam.order_management_platform.ai.exception.AIException;
 import com.ioteam.order_management_platform.ai.repository.AiRepository;
 import com.ioteam.order_management_platform.global.exception.CustomApiException;
 import com.ioteam.order_management_platform.menu.exception.MenuException;
@@ -42,9 +43,7 @@ public class AiService {
 	public AnswerAiResponseDto recommendMenuDescription(UserDetailsImpl userDetails,
 		RecommendDesRequestDto requestDto) {
 
-		// 사용자 유효성 검증 (owner이면서 해당 가게 주인인지? 필요한가
 		User user = userDetails.getUser();
-
 		Restaurant restaurant = restaurantRepository.findByResIdAndDeletedAtIsNull(requestDto.getResId())
 			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_RESTAURANT_ID));
 
@@ -55,11 +54,8 @@ public class AiService {
 
 		question += " 주어진 정보를 기반으로 <메뉴 설명> 내용을 추천해줘. 답변을 최대한 간결하게 50자 이하로 해줘.";
 
-		System.out.println(question);
-		// API 호출
 		AnswerAiResponseDto aiAnswer = requestGemini(question);
 
-		// AI의 응답 문장만 DB에 저장
 		AIResponse aiResponse = RecommendDesRequestDto.toEntity(user, question, aiAnswer);
 		AIResponse response = aiRepository.save(aiResponse);
 
@@ -67,7 +63,6 @@ public class AiService {
 	}
 
 	private AnswerAiResponseDto requestGemini(String question) {
-		//TODO: exceptio 처리
 		Map<String, Object> requestBody = Map.of(
 			"contents", new Object[] {
 				Map.of("parts", new Object[] {
@@ -76,14 +71,21 @@ public class AiService {
 			}
 		);
 
-		GeminiResponseDto aiAnswer = webClient.post()
-			.uri(geminiApiUrl + geminiApiKey)
-			.header("Content-Type", "application/json")
-			.bodyValue(requestBody)
-			.retrieve()
-			.bodyToMono(GeminiResponseDto.class)
-			.block();
+		try {
+			GeminiResponseDto aiAnswer = webClient.post()
+				.uri(geminiApiUrl + geminiApiKey)
+				.header("Content-Type", "application/json")
+				.bodyValue(requestBody)
+				.retrieve()
+				.bodyToMono(GeminiResponseDto.class)
+				.block();
 
-		return AnswerAiResponseDto.fromGemini(aiAnswer);
+			if (aiAnswer == null) {
+				throw new CustomApiException(AIException.INVALID_AI_RESPONSE);
+			}
+			return AnswerAiResponseDto.fromGemini(aiAnswer);
+		} catch (Exception e) {
+			throw new CustomApiException(AIException.AI_SERVICE_UNAVAILABLE);
+		}
 	}
 }

--- a/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
+++ b/src/main/java/com/ioteam/order_management_platform/ai/service/AiService.java
@@ -1,0 +1,96 @@
+package com.ioteam.order_management_platform.ai.service;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.ioteam.order_management_platform.ai.dto.req.RecommendDesRequestDto;
+import com.ioteam.order_management_platform.ai.dto.res.AnswerAiResponseDto;
+import com.ioteam.order_management_platform.ai.entity.AIResponse;
+import com.ioteam.order_management_platform.ai.repository.AiRepository;
+import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.menu.exception.MenuException;
+import com.ioteam.order_management_platform.restaurant.entity.Restaurant;
+import com.ioteam.order_management_platform.restaurant.repository.RestaurantRepository;
+import com.ioteam.order_management_platform.user.entity.User;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+@Service
+@Transactional
+public class AiService {
+
+	@Value("gemini.api.url")
+	private String geminiApiUrl;
+	@Value("gemini.api.key")
+	private String geminiApiKey;
+
+	private final RestaurantRepository restaurantRepository;
+	private final AiRepository aiRepository;
+	private final WebClient webClient;
+
+	public AiService(RestaurantRepository restaurantRepository, AiRepository aiRepository,
+		WebClient.Builder webClient) {
+		this.restaurantRepository = restaurantRepository;
+		this.aiRepository = aiRepository;
+		this.webClient = webClient.build();
+	}
+
+	public AnswerAiResponseDto recommendMenuDescription(UserDetailsImpl userDetails,
+		RecommendDesRequestDto requestDto) {
+
+		// 사용자 유효성 검증 (owner이면서 해당 가게 주인인지? 필요한가
+		User user = userDetails.getUser();
+		// 받아온 resId로 가게명, 음식점 카테고리 조회
+		Restaurant restaurant = restaurantRepository.findByResIdAndDeletedAtIsNull(requestDto.getResId())
+			.orElseThrow(() -> new CustomApiException(MenuException.INVALID_RESTAURANT_ID));
+
+		// // 가게명, 메뉴명, 음식점 카테고리와 OWNER의 입력 키워드로 상품 설명 추천 요청
+		String question = "가게 이름: " + restaurant.getResName()
+			+ ", 메뉴 이름: " + requestDto.getRmName()
+			+ ", 가게 카테고리: " + restaurant.getCategory();
+
+		// // 입력 텍스트의 글자수를 제한 (키워드는 10자씩? 키워드 리스트로 받아올 예정인데 리스트 내부 데이터도 제한 가능한가
+
+		// // 실제 요청 텍스트 마지막에 “답변을 최대한 간결하게 50자 이하로” 라는 텍스트를 요청시에 삽입하여 사용량을 줄이는 처리를 추가
+		question += "위의 내용을 기반으로 <메뉴 설명> 내용을 추천해줘. 답변을 최대한 간결하게 50자 이하로 해줘.";
+
+		// API 호출
+		String aiAnswer = requestGemini(question);
+
+		// OWNER의 입력 키워드의 경우 최대 5개
+
+		// AI의 응답의 문장만 DB에 저장
+		AIResponse aiResponse = RecommendDesRequestDto.toEntity(user, question, aiAnswer);
+		AIResponse response = aiRepository.save(aiResponse);
+
+		return AnswerAiResponseDto.of(response);
+	}
+
+	private String requestGemini(String question) {
+		// AI 연동
+		// 요청 payload 생성
+		// {
+		//   "contents": [{
+		//     "parts":[{"text": "Explain how AI works"}]
+		//     }]
+		//    }
+		Map<String, Object> requestBody = Map.of(
+			"contents", new Object[] {
+				Map.of("parts", new Object[] {
+					Map.of("text", question)
+				})
+			}
+		);
+
+		return webClient.post()
+			.uri(geminiApiUrl + geminiApiKey)
+			.header("Content-Type", "application/json")
+			.bodyValue(requestBody)
+			.retrieve()
+			.bodyToMono(String.class)
+			.block();
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
@@ -50,7 +50,6 @@ public enum SuccessCode {
 	PAYMENT_CREATE(HttpStatus.CREATED, "결제가 성공적으로 요청되었습니다.", "S_PAYMENT_CREATE"),
 	PAYMENT_SEARCH(HttpStatus.OK, "결제가 성공적으로 조회되었습니다.", "S_PAYMENT_SEARCH"),
 	PAYMENT_DELETE(HttpStatus.OK, "결제가 성공적으로 삭제되었습니다.", "S_PAYMENT_DELETE"),
-	// ai
 
 	// restaurant
 	RESTAURANT_CREATE(HttpStatus.OK, "가게가 성공적으로 생성되었습니다.", "S_RESTAURANT_CREATE"),
@@ -58,7 +57,11 @@ public enum SuccessCode {
 	RESTAURANT_SEARCH(HttpStatus.OK, "모든 가게가 조회되었습니다.", " S_RESTAURANT_SEARCH"),
 	RESTAURANT_MODIFY(HttpStatus.NO_CONTENT, "가게가 성공적으로 수정되었습니다.", "S_RESTAURANT_MODIFY"),
 	RESTAURANT_DELETE(HttpStatus.ACCEPTED, "가게가 성공적으로 삭제되었습니다.", "S_RESTAURANT_DELETE"),
+
+	// ai
+	AI_CREATE_MENU_DESCRIPTION(HttpStatus.OK, "메뉴 설명이 성공적으로 추천되었습니다.", "S_AI_CREATE_MENU_DESCRIPTION"),
 	;
+
 	private final HttpStatus statusCode;
 	private final String message;
 	private final String code;

--- a/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/success/SuccessCode.java
@@ -59,8 +59,7 @@ public enum SuccessCode {
 	RESTAURANT_DELETE(HttpStatus.ACCEPTED, "가게가 성공적으로 삭제되었습니다.", "S_RESTAURANT_DELETE"),
 
 	// ai
-	AI_CREATE_MENU_DESCRIPTION(HttpStatus.OK, "메뉴 설명이 성공적으로 추천되었습니다.", "S_AI_CREATE_MENU_DESCRIPTION"),
-	;
+	AI_CREATE_MENU_DESCRIPTION(HttpStatus.OK, "메뉴 설명이 성공적으로 추천되었습니다.", "S_AI_CREATE_MENU_DESCRIPTION");
 
 	private final HttpStatus statusCode;
 	private final String message;

--- a/src/main/resources/db/data.sql
+++ b/src/main/resources/db/data.sql
@@ -9,9 +9,35 @@ VALUES
     (now(), NULL, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e4'::uuid, NULL, 'd2ed72d8-090a-4efb-abe4-7acbdce120e4'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e4'::uuid, 'test4@example.com', '$2a$10$4eKGfDmoeH4VsoW9O908eOwiSD1Rkw161fVS2hAeQNHmhzlB9/xBa', 'MASTER', 'testMaster', 'nickname4'),
     (now(), NULL, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e5'::uuid, NULL, 'd2ed72d8-090a-4efb-abe4-7acbdce120e5'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e5'::uuid, 'test5@example.com', '$2a$10$4eKGfDmoeH4VsoW9O908eOwiSD1Rkw161fVS2hAeQNHmhzlB9/xBa', 'OWNER', 'testOwner2', 'nickname5');
 
+
+-- p_district 테이블 더미데이터 추가
+INSERT INTO p_district (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, district_id,
+                        district_dong_name, district_sigungu_code, district_sigungu_name)
+VALUES (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624444'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624445'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624446'::uuid,
+        '망원동' , '1234' , '서울특별시 마포구'),
+       (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624454'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624455'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624456'::uuid,
+        '합정동' , '1234' , '서울특별시 마포구'),
+       (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624554'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624655'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624756'::uuid,
+        '한남동' , '1234' , '서울특별시 마포구');
+
+
+-- p_restaurant_category 테이블 더미데이터 추가
+insert into p_restaurant_category (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, rc_id,
+                                   rc_name)
+values (now(),null,now(), 'd78dfdc2-edc6-4bec-f158-a7e055dcfc71'::uuid, null, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc72'::uuid, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc73'::uuid, '한식' ),
+       (now(),null,now(), 'd78dfdc2-edc6-4bec-f158-a7e055dcfc71'::uuid, null, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc72'::uuid, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc74'::uuid, '양식' );
+
+
 -- p_restaurant 테이블 목데이터 추가
-INSERT INTO p_restaurant (created_at, modified_at, created_by, modified_by, res_id, res_phone, res_address, res_name, res_image_url, res_owner_id)
-VALUES (now(), now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '02-0000-0000', '서울시 스파르타 스파르타동 스번지', '스파르타파스타', null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid);
+INSERT INTO p_restaurant (created_at, modified_at, created_by, modified_by, res_id, res_phone, res_address, res_name, res_image_url, res_owner_id, res_category_id)
+VALUES (now(), now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, '02-0000-0000', '서울시 스파르타 스파르타동 스번지', '스파르타파스타', null, 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc74'::uuid);
+
+insert into p_restaurant (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, res_category_id,
+                          res_district_id, res_id, res_owner_id, res_phone, res_address, res_name, res_image_url)
+values (now(),null,now(),'768f5a3b-e6d8-46d6-f953-b9c425ab1cf9'::uuid, null, '768f5a3b-e6d8-46d6-f953-b9c425ab1cf0'::uuid,'d78dfdc2-edc6-4bec-f158-a7e055dcfc73'::uuid,
+        'd6df52e4-6ec8-4d46-b0c2-90f5f2624446'::uuid,'768f5a3b-e6d8-46d6-f953-b9c425ab1cf1'::uuid , 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '010-1234-5678' ,
+        '재현건물1층1호', '건물주', null);
+
 
 -- p_restaurant_score 테이블 목데이터 추가
 INSERT INTO p_restaurant_score
@@ -77,23 +103,6 @@ VALUES
     ('d8ef5ca7-2b3c-49bb-9c6d-425c85036de9'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, true, 2, now(), NULL, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, NULL, 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, '1c114e8f-ccd0-42b8-a7fa-67fee61d4d67'::uuid, 'test', 'test'),
     ('d8ef5ca7-2b3c-49bb-9c6d-425c85036de0'::uuid, '3fa85f64-5717-4562-b3fc-2c963f66afa6'::uuid, 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, true, 1, now(), NULL, now(), 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, NULL, 'd2ed72d8-090a-4efb-abe4-7acbdce120e1'::uuid, '1c114e8f-ccd0-42b8-a7fa-67fee61d4d13'::uuid, 'test', 'test');
 
--- p_district 테이블 더미데이터 추가
-INSERT INTO p_district (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, district_id,
-                        district_dong_name, district_sigungu_code, district_sigungu_name)
-VALUES (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624444'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624445'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624446'::uuid,
-        '망원동' , '1234' , '서울특별시 마포구'),
-       (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624454'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624455'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624456'::uuid,
-        '합정동' , '1234' , '서울특별시 마포구'),
-       (now(), null, now(), 'd6df52e4-6ec8-4d46-b0c2-90f5f2624554'::uuid, null, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624655'::uuid, 'd6df52e4-6ec8-4d46-b0c2-90f5f2624756'::uuid,
-        '한남동' , '1234' , '서울특별시 마포구');
 
--- p_restaurant_category 테이블 더미데이터 추가
-insert into p_restaurant_category (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, rc_id,
-                                   rc_name)
-values (now(),null,now(), 'd78dfdc2-edc6-4bec-f158-a7e055dcfc71'::uuid, null, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc72'::uuid, 'd78dfdc2-edc6-4bec-f158-a7e055dcfc73'::uuid, '한식' );
--- p_restaurant 테이블 더미데이터 추가
-insert into p_restaurant (created_at, deleted_at, modified_at, created_by, deleted_by, modified_by, res_category_id,
-                          res_district_id, res_id, res_owner_id, res_phone, res_address, res_name, res_image_url)
-values (now(),null,now(),'768f5a3b-e6d8-46d6-f953-b9c425ab1cf9'::uuid, null, '768f5a3b-e6d8-46d6-f953-b9c425ab1cf0'::uuid,'d78dfdc2-edc6-4bec-f158-a7e055dcfc73'::uuid,
-       'd6df52e4-6ec8-4d46-b0c2-90f5f2624446'::uuid,'768f5a3b-e6d8-46d6-f953-b9c425ab1cf1'::uuid , 'd2ed72d8-090a-4efb-abe4-7acbdce120e2'::uuid, '010-1234-5678' ,
-        '재현건물1층1호', '건물주', null);
+
+

--- a/src/main/resources/properties/key.yml
+++ b/src/main/resources/properties/key.yml
@@ -6,3 +6,7 @@ jwt:
     master: ${MASTER_TOKEN}
     manager: ${MANAGER_TOKEN}
     owner: ${OWNER_TOKEN}
+gemini:
+  api:
+    url: ${GEMINI_API_URL}
+    key: ${GEMINI_API_KEY}


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**

- **to-be**
  - AI 연동
  - 가게명, 메뉴명, 음식점 카테고리와 OWNER의 입력 키워드로 상품 설명 추천 요청
  - OWNER의 입력 키워드의 경우 최대 5개
  - AI의 응답의 문장만 DB에 저장
  - 입력 텍스트의 글자수를 제한
  - 실제 요청 텍스트 마지막에 “답변을 최대한 간결하게 50자 이하로” 라는 텍스트를 요청시에 삽입하여 사용량을 줄이는 처리

## 코멘트
- 서브모듈 업데이트할 때  stash했으면 됐군요.. 이제 생각났습니다
**### - env 파일에 AI관련 추가되었습니다!**
