### PR TITLE
feat: Pageable 페이지 사이즈 제한 기능 추가 #160

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/global/config/CustomPageableArgumentResolver.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/config/CustomPageableArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.ioteam.order_management_platform.global.config;
+
+import java.util.Set;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CustomPageableArgumentResolver extends PageableHandlerMethodArgumentResolver {
+
+	private static final Set<Integer> ALLOWED_PAGE_SIZES = Set.of(10, 30, 50); // 사이즈 제한
+	private static final int DEFAULT_PAGE_SIZE = 10; // 기본값
+
+	@Override
+	public Pageable resolveArgument(MethodParameter methodParameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory) {
+
+		Pageable pageable = super.resolveArgument(methodParameter, mavContainer, webRequest, binderFactory);
+
+		int pageSize = pageable.getPageSize();
+
+		// 요청된 페이지 사이즈가 허용된 값이 아닐 경우 기본값으로 설정
+		if (!ALLOWED_PAGE_SIZES.contains(pageSize)) {
+			return PageRequest.of(pageable.getPageNumber(), DEFAULT_PAGE_SIZE, pageable.getSort());
+		}
+
+		return pageable;
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/global/config/WebConfig.java
+++ b/src/main/java/com/ioteam/order_management_platform/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.ioteam.order_management_platform.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(new CustomPageableArgumentResolver());
+	}
+}


### PR DESCRIPTION
## 변경 타입
- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - Pageable로 받아온 pageable 객체를 제한 조건에 맞춰 검증하는 로직이 각각의 도메인마다 작성되었어야 함.

- **to-be**
  - PageableHandlerArgumentResolver를 상속받는 CustomPageableArgumentResolver 생성
  - 페이지 사이즈 10, 30, 50 제한
  - 허용되지 않은 사이즈 요청시 기본값 10 설정

## 코멘트
