### PR TITLE
Refactor/#179 payment get payment refactoring

### DIFF
--- a/src/main/java/com/ioteam/order_management_platform/payment/entity/Payment.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/entity/Payment.java
@@ -69,4 +69,5 @@ public class Payment extends BaseEntity {
 		// 상태 변경
 		this.paymentStatus = newStatus;
 	}
+
 }

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/PaymentService.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/PaymentService.java
@@ -38,44 +38,6 @@ public class PaymentService {
 	private final RestaurantRepository restaurantRepository;
 	private final PaymentRetrieveStrategies paymentRetrieveStrategist;
 
-	public PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails) {
-		UserRoleEnum role = userDetails.getRole();
-
-		return paymentRetrieveStrategist.stream()
-			.filter(it -> it.isSupport(role))
-			.findAny()
-			.orElseThrow(() -> new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS))
-			.getPayment(paymentId, userDetails);
-
-	}
-
-	// // MASTER, MANAGER: 모든 결제 내역 조회 가능
-	// if (userDetails.getRole() == UserRoleEnum.MASTER || userDetails.getRole() == UserRoleEnum.MANAGER) {
-	// 	Payment payment = paymentRepository.findByPaymentIdAndDeletedAtIsNull(paymentId)
-	// 		.orElseThrow(() -> new CustomApiException(PaymentException.INVALID_PAYMENT_ID));
-	// 	return PaymentResponseDto.from(payment);
-	// }
-	//
-	// // CUSTOMER: 본인이 주문한 결제 내역만 조회 가능
-	// if (userDetails.getRole() == UserRoleEnum.CUSTOMER) {
-	// 	Payment payment = paymentRepository.findPaymentForCustomer(paymentId, userDetails.getUserId())
-	// 		.orElseThrow(() -> new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS));
-	// 	return PaymentResponseDto.from(payment);
-	// }
-	//
-	// // OWNER: 본인 가게의 주문 결제 내역만 조회 가능
-	// if (userDetails.getRole() == UserRoleEnum.OWNER) {
-	// 	Payment payment = paymentRepository.findPaymentWithOrderAndRestaurant(paymentId)
-	// 		.orElseThrow(() -> new CustomApiException(PaymentException.INVALID_PAYMENT_ID));
-	//
-	// 	// 본인이 해당 가게의 주인인지 확인
-	// 	if (!payment.getOrder().getRestaurant().getOwner().getUserId().equals(userDetails.getUserId())) {
-	// 		throw new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS);
-	// 	}
-	// 	return PaymentResponseDto.from(payment);
-	// }
-	//
-	// throw new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS);
 	@Transactional
 	public PaymentResponseDto createPayment(UserDetailsImpl userDetails, CreatePaymentRequestDto requestDto) {
 		// 주문이 유효한지, 주문자가 본인인지, 주문이 삭제되지 않았는지 확인
@@ -97,6 +59,17 @@ public class PaymentService {
 		Page<AdminPaymentResponseDto> paymentDtoPage = paymentRepository.searchPaymentAdminByCondition(condition,
 			pageable);
 		return new CommonPageResponse<>(paymentDtoPage);
+	}
+
+	public PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails) {
+		UserRoleEnum role = userDetails.getRole();
+
+		return paymentRetrieveStrategist.stream()
+			.filter(it -> it.isSupport(role))
+			.findAny()
+			.orElseThrow(() -> new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS))
+			.getPayment(paymentId, userDetails);
+
 	}
 
 	public CommonPageResponse<PaymentResponseDto> searchPaymentByUser(CustomerPaymentSearchCondition condition,

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/PaymentRetrieveStrategies.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/PaymentRetrieveStrategies.java
@@ -1,0 +1,18 @@
+package com.ioteam.order_management_platform.payment.service.strategy;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentRetrieveStrategies {
+	private final List<PaymentRetrieveStrategy> strategies;
+
+	public Stream<PaymentRetrieveStrategy> stream() {
+		return strategies.stream();
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/PaymentRetrieveStrategy.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/PaymentRetrieveStrategy.java
@@ -1,0 +1,14 @@
+package com.ioteam.order_management_platform.payment.service.strategy;
+
+import java.util.UUID;
+
+import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+public interface PaymentRetrieveStrategy {
+	boolean isSupport(UserRoleEnum userRole);
+
+	PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails);
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/AdminPaymentRetrieveStrategy.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/AdminPaymentRetrieveStrategy.java
@@ -1,0 +1,34 @@
+package com.ioteam.order_management_platform.payment.service.strategy.role;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
+import com.ioteam.order_management_platform.payment.entity.Payment;
+import com.ioteam.order_management_platform.payment.exception.PaymentException;
+import com.ioteam.order_management_platform.payment.repository.PaymentRepository;
+import com.ioteam.order_management_platform.payment.service.strategy.PaymentRetrieveStrategy;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminPaymentRetrieveStrategy implements PaymentRetrieveStrategy {
+	private final PaymentRepository paymentRepository;
+
+	@Override
+	public boolean isSupport(UserRoleEnum role) {
+		return role == UserRoleEnum.MANAGER || role == UserRoleEnum.MASTER;
+	}
+
+	@Override
+	public PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails) {
+		Payment payment = paymentRepository.findByPaymentIdAndDeletedAtIsNull(paymentId)
+			.orElseThrow(() -> new CustomApiException(PaymentException.INVALID_PAYMENT_ID));
+		return PaymentResponseDto.from(payment);
+	}
+}

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/CustomerPaymentRetrieveStrategy.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/CustomerPaymentRetrieveStrategy.java
@@ -1,0 +1,36 @@
+package com.ioteam.order_management_platform.payment.service.strategy.role;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
+import com.ioteam.order_management_platform.payment.entity.Payment;
+import com.ioteam.order_management_platform.payment.exception.PaymentException;
+import com.ioteam.order_management_platform.payment.repository.PaymentRepository;
+import com.ioteam.order_management_platform.payment.service.strategy.PaymentRetrieveStrategy;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomerPaymentRetrieveStrategy implements PaymentRetrieveStrategy {
+
+	private final PaymentRepository paymentRepository;
+
+	@Override
+	public boolean isSupport(UserRoleEnum role) {
+		return role == UserRoleEnum.CUSTOMER;
+	}
+
+	@Override
+	public PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails) {
+		Payment payment = paymentRepository.findPaymentForCustomer(paymentId, userDetails.getUserId())
+			.orElseThrow(() -> new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS));
+		return PaymentResponseDto.from(payment);
+	}
+
+}

--- a/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/OwnerPaymentRetrieveStrategy.java
+++ b/src/main/java/com/ioteam/order_management_platform/payment/service/strategy/role/OwnerPaymentRetrieveStrategy.java
@@ -1,0 +1,39 @@
+package com.ioteam.order_management_platform.payment.service.strategy.role;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.ioteam.order_management_platform.global.exception.CustomApiException;
+import com.ioteam.order_management_platform.payment.dto.res.PaymentResponseDto;
+import com.ioteam.order_management_platform.payment.entity.Payment;
+import com.ioteam.order_management_platform.payment.exception.PaymentException;
+import com.ioteam.order_management_platform.payment.repository.PaymentRepository;
+import com.ioteam.order_management_platform.payment.service.strategy.PaymentRetrieveStrategy;
+import com.ioteam.order_management_platform.user.entity.UserRoleEnum;
+import com.ioteam.order_management_platform.user.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OwnerPaymentRetrieveStrategy implements PaymentRetrieveStrategy {
+	private final PaymentRepository paymentRepository;
+
+	@Override
+	public boolean isSupport(UserRoleEnum role) {
+		return role == UserRoleEnum.OWNER;
+	}
+
+	@Override
+	public PaymentResponseDto getPayment(UUID paymentId, UserDetailsImpl userDetails) {
+		Payment payment = paymentRepository.findPaymentWithOrderAndRestaurant(paymentId)
+			.orElseThrow(() -> new CustomApiException(PaymentException.INVALID_PAYMENT_ID));
+
+		// 본인이 해당 가게의 주인인지 확인
+		if (!payment.getOrder().getRestaurant().isOwner(userDetails)) {
+			throw new CustomApiException(PaymentException.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+		return PaymentResponseDto.from(payment);
+	}
+}


### PR DESCRIPTION
## 변경 타입
- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 서비스 메소드 내부에 권한별 조건 처리 로직 구현

- **to-be**
  - 권한별로 처리하는 전략 패턴(권한이 추가됨에 따라 인터페이스 구현체를 추가하는 방식)을 적용

## 코멘트
- 전략 패턴의 흐름

1. 하나의 전략 인터페이스를 기준으로 권한별 구현체 클래스를 만듭니다.
2. 구현체를 List<PaymentRetrieveStrategy> 형태로 관리하는 클래스를 만듭니다.
3. stream 메소드로 구현체를 하나씩 꺼내고 filter로 권한에 맞는 구현체를 선택해 권한에 따른 처리 로직을 실행합니다.

- 패키지 구조 관련해서 전략 패키지 만들고 전략 클래스와 인터페이스를 넣고, 전략 패키지 안에 권한 패키지를 만들어서 그 안에 권한별 로직 처리 클래스들을 관리하는 구조로 구성했는데, 괜찮은지 모르겠습니다! 더 좋은 의견이 있다면 알려주세요!

- 추가적으로 Restaurant 엔티티의 메소드 isOwner 를 활용해 가독성을 좀 더 높여봤습니다. 더 좋은 방법이 있을지 고민입니다. payment.getOrder().getRestaurant().getOwner().getUserId().equals(userDetails.getUserId()) -> payment.getOrder().getRestaurant().isOwner(userDetails)

- 해당 전략패턴을 구성한게 효율적이라고 판단되면 다른 결제 관련 서비스에서도 이러한 전략을 적용할 것 같습니다.